### PR TITLE
Python3, disk-> data,  allow parity disk to be used for content file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_run_path: /opt/snapraid-runner/snapraid-runner
 snapraid_run_conf: "{{ snapraid_run_path }}.conf"
 snapraid_run_bin: "{{ snapraid_run_path }}.py"
-snapraid_run_command: "python2 {{ snapraid_run_bin }} -c {{ snapraid_run_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_healthcheck_io_uuid }} > /dev/null"
+snapraid_run_command: "python3 {{ snapraid_run_bin }} -c {{ snapraid_run_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_healthcheck_io_uuid }} > /dev/null"
 snapraid_run_scrub: true
 snapraid_run_scrub_percent: 22
 snapraid_run_scrub_age: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ snapraid_healthcheck_io_uuid: ""
 
 snapraid_email_address: ""
 snapraid_gmail_pass: ""
+snapraid_email_address_from: "{{ snapraid_email_address }}"
+snapraid_email_address_to: "{{ snapraid_email_address }}"
 
 snapraid_config_excludes: []
 snapraid_config_hidden_files_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
+snapraid_force_install: false
 
 snapraid_healthcheck_io_uuid: ""
 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -6,25 +6,29 @@
   register: is_installed
   changed_when: "is_installed.rc != 0"
 
+- name: install snapraid?
+  set_fact:
+    install_snapraid: "{{ snapraid_force_install is true or is_installed is failed }}"
+
 - name: build snapraid | clone git repo
   git:
     repo: https://github.com/IronicBadger/docker-snapraid.git
     dest: /tmp/snapraid
     force: yes
-  when: is_installed is failed
+  when: install_snapraid
 
 - name: build snapraid | make build script executable
   file:
     path: /tmp/snapraid/build.sh
     mode: 0775
-  when: is_installed is failed
+  when: install_snapraid
 
 - name: build snapraid | build .deb package
   shell: cd /tmp/snapraid && ./build.sh
-  when: is_installed is failed
+  when: install_snapraid
 
 - name: build snapraid | install built .deb
   apt:
     deb: /tmp/snapraid/build/snapraid-from-source.deb
     state: present
-  when: is_installed is failed
+  when: install_snapraid

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -20,8 +20,8 @@ sendon = error
 ; set to false to get full program output via email
 short = true
 subject = [SnapRAID] Status Report:
-from = {{ snapraid_email_address }}
-to = {{ snapraid_email_address }}
+from = {{ snapraid_email_address_from }}
+to = {{ snapraid_email_address_to }}
 
 [smtp]
 host = smtp.gmail.com

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -17,7 +17,7 @@ content {{ disk.path }}/.snapraid.content
 
 # Data disks
 {% for disk in data_disks %}
-disk d{{ loop.index }} {{ disk.path }}
+data d{{ loop.index }} {{ disk.path }}
 {% endfor %}
 
 # Excludes hidden files and directories (uncomment to enable).

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -9,6 +9,11 @@
 
 # Content file location(s)
 content /var/snapraid.content
+{% for disk in parity_disks %}
+{% if disk.content == true %}
+content {{ disk.path }}/snapraid.content
+{% endif %}
+{% endfor %}
 {% for disk in data_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/.snapraid.content


### PR DESCRIPTION
Modernization changes:
* use python3 insead of python2 
* rename `disk` to `data` in snapraid.conf

Features:
* allow parity disk to be used for content file