### PR TITLE
feat: Make email condition configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ snapraid_email_address: ""
 snapraid_gmail_pass: ""
 snapraid_email_address_from: "{{ snapraid_email_address }}"
 snapraid_email_address_to: "{{ snapraid_email_address }}"
+snapraid_email_sendon: "error"
 
 snapraid_config_excludes: []
 snapraid_config_hidden_files_enabled: false

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -16,7 +16,7 @@ maxsize = 5000
 
 [email]
 ; when to send an email, comma-separated list of [success, error]
-sendon = error
+sendon = {{ snapraid_email_sendon }}
 ; set to false to get full program output via email
 short = true
 subject = [SnapRAID] Status Report:


### PR DESCRIPTION
I like getting emails on every success and failure. Making the `sendon` condition configurable, but leaving the default to `"error"`. Allows end user to override `snapraid_email_sendon` to `"success, failure"` if desired.