### PR TITLE
Fix install-debian install snapraid play

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -8,7 +8,7 @@
 
 - name: install snapraid?
   set_fact:
-    install_snapraid: "{{ snapraid_force_install is true or is_installed is failed }}"
+    install_snapraid: "{{ snapraid_force_install == true or is_installed.failed == true }}"
 
 - name: build snapraid | clone git repo
   git:


### PR DESCRIPTION
The jinga wasn't working for me and kept spitting out an error/refusing to get past the snapraid install check.  This should fix it, at least it did on my system.