### PR TITLE
Allow for changing the path to or removing the main content file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ snapraid_smtp_host: smtp.gmail.com
 snapraid_smtp_port: 465
 snapraid_use_ssl: true
 
+snapraid_content: /var/snapraid.content
+
 snapraid_config_excludes: []
 snapraid_config_hidden_files_enabled: false
 snapraid_config_hidden_files: nohidden

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,20 @@
 ---
 
+- name: check valid configuration
+  block:
+    - fail:
+        msg: No data disks defined
+      when: data_disks | length == 0
+    - fail:
+        msg: No parity disks defined
+      when: parity_disks | length == 0
+    - fail:
+        msg: No content files defined
+      when:
+        - snapraid_content == ''
+        - data_disks | selectattr('content') | length == 0
+        - parity_disks | selectattr('content') | length == 0
+
 - name: install snapraid config file
   template:
     src: snapraid.conf.j2

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -8,7 +8,7 @@
 
 - name: install snapraid?
   set_fact:
-    install_snapraid: "{{ snapraid_force_install is true or is_installed is failed }}"
+    install_snapraid: "{{ snapraid_force_install == true or is_installed.failed == true }}"
 
 - name: build snapraid | clone git repo
   git:

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -8,7 +8,9 @@
 {% endfor %}
 
 # Content file location(s)
-content /var/snapraid.content
+{% if snapraid_content != '' %}
+content {{ snapraid_content }}
+{% endif %}
 {% for disk in parity_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/snapraid.content


### PR DESCRIPTION
When running on a Raspberry Pi, keeping a content file on the SD card will just cause unnecessary wear.

This also adds a couple of configuration checks to ensure that a content file exists, and data/parity disks are defined