### PR TITLE
Allow running plain snapraid cron, and a whole lot more...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # ansible-role-snapraid
+
+An ansible role to install and configure [snapraid](https://www.snapraid.it/) and (optionally) [snapraid-runner](https://github.com/Chronial/snapraid-runner).
+
+## Features
+
+- Installation and configuration of `snapraid-runner` to aid scrubbing (optional)
+- Automated creation of `sync` and `scrub` jobs
+- [Healthchecks.io](https://healthchecks.io/) integration for cron jobs (optional)
+
+## Configuration
+
+This role has [many](./defaults/main.yml) variables which can be configured.
+
+### Example
+
+```yaml
+snapraid_install: false
+snapraid_runner: false
+
+snapraid_data_disks:
+  - path: /mnt/disk1
+    content: true
+  - path: /mnt/disk2
+    content: true
+
+snapraid_parity_disks:
+  - path: /mnt/parity1
+    content: true
+
+snapraid_content_files:
+  - /mnt/other-drive/snapraid.content
+  - /var/snapraid.content
+
+snapraid_config_excludes:
+  - "*.unrecoverable"
+  - /lost+found/
+  - "*.!sync"
+  - /tmp/
+
+snapraid_scrub_schedule:
+  hour: 5
+  weekday: 4
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 # ansible-role-snapraid
-
-Requires Docker to build snapraid package

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} && curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary '@-' {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,9 +31,18 @@ snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
 snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null"
 snapraid_runner_scrub: true
-snapraid_runner_scrub_percent: 22
-snapraid_runner_scrub_age: 8
+snapraid_scrub_percent: 22
+snapraid_scrub_age: 8
 snapraid_runner_touch: true
 
 snapraid_runner_cron_jobs:
   - { job: '{{ snapraid_runner_command }}', name: 'snapraid_runner', weekday: '*', hour: '01' }
+
+snapraid_sync_schedule:
+  minute: 0
+  hour: 0
+
+snapraid_scrub_schedule:
+  minute: 0
+  hour: 0
+  weekday: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+snapraid_install: true
+snapraid_runner: true
+
 snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary '@-' {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary '@-' {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 
 snapraid_runner_healthcheck_io_uuid: ""
+snapraid_healthcheck_io_host: https://hc-ping.com
 
 snapraid_runner_email_address: ""
 snapraid_runner_gmail_pass: ""
@@ -29,7 +30,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} && curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8
@@ -41,8 +42,10 @@ snapraid_runner_cron_jobs:
 snapraid_sync_schedule:
   minute: 0
   hour: 0
+snapraid_sync_healthcheck_io_uuid: ""
 
 snapraid_scrub_schedule:
   minute: 0
   hour: 0
   weekday: 0
+snapraid_scrub_healthcheck_io_uuid: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8
 snapraid_runner_touch: true
+snapraid_runner_delete_threshold: 250
 
 snapraid_runner_cron_jobs:
   - { job: '{{ snapraid_runner_command }}', name: 'snapraid_runner', weekday: '*', hour: '01' }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,8 @@ snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465
 snapraid_runner_use_ssl: true
 
-snapraid_content: /var/snapraid.content
+snapraid_content_files:
+  - /var/snapraid.content
 
 snapraid_config_excludes: []
 snapraid_config_hidden_files_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ snapraid_runner_email_address: ""
 snapraid_runner_gmail_pass: ""
 snapraid_runner_email_address_from: "{{ snapraid_runner_email_address }}"
 snapraid_runner_email_address_to: "{{ snapraid_runner_email_address }}"
-snapraid_runner_smtp_host: "error"
+snapraid_runner_email_sendon: "error"
 
 snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,17 +7,17 @@ snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 
-snapraid_healthcheck_io_uuid: ""
+snapraid_runner_healthcheck_io_uuid: ""
 
-snapraid_email_address: ""
-snapraid_gmail_pass: ""
-snapraid_email_address_from: "{{ snapraid_email_address }}"
-snapraid_email_address_to: "{{ snapraid_email_address }}"
-snapraid_email_sendon: "error"
+snapraid_runner_email_address: ""
+snapraid_runner_gmail_pass: ""
+snapraid_runner_email_address_from: "{{ snapraid_runner_email_address }}"
+snapraid_runner_email_address_to: "{{ snapraid_runner_email_address }}"
+snapraid_runner_smtp_host: "error"
 
-snapraid_smtp_host: smtp.gmail.com
-snapraid_smtp_port: 465
-snapraid_use_ssl: true
+snapraid_runner_smtp_host: smtp.gmail.com
+snapraid_runner_smtp_port: 465
+snapraid_runner_use_ssl: true
 
 snapraid_content: /var/snapraid.content
 
@@ -26,14 +26,14 @@ snapraid_config_hidden_files_enabled: false
 snapraid_config_hidden_files: nohidden
 snapraid_config_path: /etc/snapraid.conf
 
-snapraid_run_path: /opt/snapraid-runner/snapraid-runner
-snapraid_run_conf: "{{ snapraid_run_path }}.conf"
-snapraid_run_bin: "{{ snapraid_run_path }}.py"
-snapraid_run_command: "python3 {{ snapraid_run_bin }} -c {{ snapraid_run_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_healthcheck_io_uuid }} > /dev/null"
-snapraid_run_scrub: true
-snapraid_run_scrub_percent: 22
-snapraid_run_scrub_age: 8
-snapraid_touch: true
+snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
+snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
+snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf}} && curl -fsS --retry 3 https://hc-ping.com/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null"
+snapraid_runner_scrub: true
+snapraid_runner_scrub_percent: 22
+snapraid_runner_scrub_age: 8
+snapraid_runner_touch: true
 
-snapraid_cron_jobs:
-  - { job: '{{ snapraid_run_command }}', name: 'snapraid_runner', weekday: '*', hour: '01' }
+snapraid_runner_cron_jobs:
+  - { job: '{{ snapraid_runner_command }}', name: 'snapraid_runner', weekday: '*', hour: '01' }

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,16 +4,16 @@
   block:
     - fail:
         msg: No data disks defined
-      when: data_disks | length == 0
+      when: snapraid_data_disks | length == 0
     - fail:
         msg: No parity disks defined
-      when: parity_disks | length == 0
+      when: snapraid_parity_disks | length == 0
     - fail:
         msg: No content files defined
       when:
         - snapraid_content_files | length == 0
-        - data_disks | selectattr('content') | length == 0
-        - parity_disks | selectattr('content') | length == 0
+        - snapraid_data_disks | selectattr('content') | length == 0
+        - snapraid_parity_disks | selectattr('content') | length == 0
 
 - name: install snapraid config file
   template:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
     - fail:
         msg: No content files defined
       when:
-        - snapraid_content == ''
+        - snapraid_content_files | length == 0
         - data_disks | selectattr('content') | length == 0
         - parity_disks | selectattr('content') | length == 0
 

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -3,7 +3,7 @@
 - name: Schedule snapraid sync
   cron:
     name: snapraid sync
-    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
+    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_sync_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_sync_schedule.minute | default ('0')}}"
@@ -13,7 +13,7 @@
 - name: Schedule snapraid scrub
   cron:
     name: snapraid scrub
-    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
+    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_scrub_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_scrub_schedule.minute | default ('0')}}"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Schedule snapraid sync
+  cron:
+    name: snapraid sync
+    job: snapraid sync
+    user: root
+    weekday: "{{ snapraid_sync_schedule.weekday | default ('*') }}"
+    minute: "{{ snapraid_sync_schedule.minute | default ('0')}}"
+    hour: "{{ snapraid_sync_schedule.hour | default ('0') }}"
+    dom: "{{ snapraid_sync_schedule.dom|default('*') }}"
+
+- name: Schedule snapraid scrub
+  cron:
+    name: snapraid scrub
+    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }}
+    user: root
+    weekday: "{{ snapraid_scrub_schedule.weekday | default ('*') }}"
+    minute: "{{ snapraid_scrub_schedule.minute | default ('0')}}"
+    hour: "{{ snapraid_scrub_schedule.hour | default ('0') }}"
+    dom: "{{ snapraid_scrub_schedule.dom|default('*') }}"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -3,7 +3,7 @@
 - name: Schedule snapraid sync
   cron:
     name: snapraid sync
-    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
+    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_sync_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_sync_schedule.minute | default ('0')}}"
@@ -13,7 +13,7 @@
 - name: Schedule snapraid scrub
   cron:
     name: snapraid scrub
-    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}| curl -fsS --retry 3 --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
+    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_scrub_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_scrub_schedule.minute | default ('0')}}"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -3,7 +3,7 @@
 - name: Schedule snapraid sync
   cron:
     name: snapraid sync
-    job: snapraid sync
+    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_sync_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_sync_schedule.minute | default ('0')}}"
@@ -13,7 +13,7 @@
 - name: Schedule snapraid scrub
   cron:
     name: snapraid scrub
-    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }}
+    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}&& curl -fsS --retry 3 {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_scrub_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_scrub_schedule.minute | default ('0')}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,3 +10,7 @@
 - name: install and configure snapraid-runner
   include_tasks: parity-checks.yml
   when: snapraid_runner
+
+- name: schedule snapraid
+  include_tasks: cron.yml
+  when: not snapraid_runner

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,11 @@
 
 - name: install snapraid
   include_tasks: install-debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and snapraid_install
 
 - name: configure snapraid
   include_tasks: configure.yml
 
-- name: automate parity checks
+- name: install and configure snapraid-runner
   include_tasks: parity-checks.yml
+  when: snapraid_runner

--- a/tasks/snapraid-runner.yml
+++ b/tasks/snapraid-runner.yml
@@ -8,10 +8,10 @@
 - name: install snapraid-runner configuration file
   template:
     src: snapraid-runner.conf.j2
-    dest: "{{ snapraid_run_conf }}"
+    dest: "{{ snapraid_runner_conf }}"
     owner: root
     group: root
-    mode: 0775  
+    mode: 0775
 
 - name: setup cron job snapraid-runner
   cron:
@@ -23,5 +23,4 @@
     hour: "{{ item.hour | default ('00') }}"
     dom: "{{ item.dom|default('*') }}"
   with_items:
-    - "{{ snapraid_cron_jobs }}"
-    
+    - "{{ snapraid_runner_cron_jobs }}"

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -6,7 +6,7 @@ config = {{ snapraid_config_path }}
 ; abort operation if there are more deletes than this, set to -1 to disable
 deletethreshold = 250
 ; if you want touch to be run each time
-touch = {{ snapraid_touch }}
+touch = {{ snapraid_runner_touch }}
 
 [logging]
 ; logfile to write to, leave empty to disable
@@ -16,24 +16,24 @@ maxsize = 5000
 
 [email]
 ; when to send an email, comma-separated list of [success, error]
-sendon = {{ snapraid_email_sendon }}
+sendon = {{ snapraid_runner_smtp_host }}
 ; set to false to get full program output via email
 short = true
 subject = [SnapRAID] Status Report:
-from = {{ snapraid_email_address_from }}
-to = {{ snapraid_email_address_to }}
+from = {{ snapraid_runner_email_address_from }}
+to = {{ snapraid_runner_email_address_to }}
 
 [smtp]
-host = {{ snapraid_smtp_host }}
+host = {{ snapraid_runner_smtp_host }}
 ; leave empty for default port
-port = {{ snapraid_smtp_port }}
+port = {{ snapraid_runner_smtp_port }}
 ; set to "true" to activate
-ssl = {{ snapraid_use_ssl }}
-user = {{ snapraid_email_address }}
-password = {{ snapraid_gmail_pass }}
+ssl = {{ snapraid_runner_use_ssl }}
+user = {{ snapraid_runner_email_address }}
+password = {{ snapraid_runner_gmail_pass }}
 
 [scrub]
 ; set to true to run scrub after sync
-enabled = {{ snapraid_run_scrub }}
-percentage = {{ snapraid_run_scrub_percent }}
-older-than = {{ snapraid_run_scrub_age }}
+enabled = {{ snapraid_runner_scrub }}
+percentage = {{ snapraid_runner_scrub_percent }}
+older-than = {{ snapraid_runner_scrub_age }}

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -4,7 +4,7 @@ executable = {{ snapraid_bin_path }}
 ; path to the snapraid config to be used
 config = {{ snapraid_config_path }}
 ; abort operation if there are more deletes than this, set to -1 to disable
-deletethreshold = 250
+deletethreshold = {{ snapraid_runner_delete_threshold }}
 ; if you want touch to be run each time
 touch = {{ snapraid_runner_touch }}
 

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -35,5 +35,5 @@ password = {{ snapraid_runner_gmail_pass }}
 [scrub]
 ; set to true to run scrub after sync
 enabled = {{ snapraid_runner_scrub }}
-percentage = {{ snapraid_runner_scrub_percent }}
-older-than = {{ snapraid_runner_scrub_age }}
+percentage = {{ snapraid_scrub_percent }}
+older-than = {{ snapraid_scrub_age }}

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -16,7 +16,7 @@ maxsize = 5000
 
 [email]
 ; when to send an email, comma-separated list of [success, error]
-sendon = {{ snapraid_runner_smtp_host }}
+sendon = {{ snapraid_runner_email_sendon }}
 ; set to false to get full program output via email
 short = true
 subject = [SnapRAID] Status Report:

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -8,9 +8,6 @@
 {% endfor %}
 
 # Content file location(s)
-{% if snapraid_content != '' %}
-content {{ snapraid_content }}
-{% endif %}
 {% for disk in parity_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/snapraid.content
@@ -20,6 +17,9 @@ content {{ disk.path }}/snapraid.content
 {% if disk.content == true %}
 content {{ disk.path }}/.snapraid.content
 {% endif %}
+{% endfor %}
+{% for content_file in snapraid_content_files %}
+content {{ content_file }}
 {% endfor %}
 
 # Data disks

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -3,17 +3,17 @@
 # SnapRAID configuration file
 
 # Parity location(s)
-{% for disk in parity_disks %}
+{% for disk in snapraid_parity_disks %}
 {{ loop.index}}-parity {{ disk.path }}/snapraid.parity
 {% endfor %}
 
 # Content file location(s)
-{% for disk in parity_disks %}
+{% for disk in snapraid_parity_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/snapraid.content
 {% endif %}
 {% endfor %}
-{% for disk in data_disks %}
+{% for disk in snapraid_data_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/.snapraid.content
 {% endif %}
@@ -23,7 +23,7 @@ content {{ content_file }}
 {% endfor %}
 
 # Data disks
-{% for disk in data_disks %}
+{% for disk in snapraid_data_disks %}
 data d{{ loop.index }} {{ disk.path }}{{ disk.data_path | default('') }}
 {% endfor %}
 

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -8,6 +8,9 @@
 {% endfor %}
 
 # Content file location(s)
+{% for content_file in snapraid_content_files %}
+content {{ content_file }}
+{% endfor %}
 {% for disk in snapraid_parity_disks %}
 {% if disk.content == true %}
 content {{ disk.path }}/snapraid.content
@@ -17,9 +20,6 @@ content {{ disk.path }}/snapraid.content
 {% if disk.content == true %}
 content {{ disk.path }}/.snapraid.content
 {% endif %}
-{% endfor %}
-{% for content_file in snapraid_content_files %}
-content {{ content_file }}
 {% endfor %}
 
 # Data disks


### PR DESCRIPTION
This PR mostly enables the ability of scheduling a plain `snapraid sync` / `snapraid scrub`, without using `snapraid-runner`. Personally, I'd rather just schedule and manage things myself without the wrapper. It also allows not installing `snapraid` itself using Docker, which removes a dependency on using the role.

In the end, this PR became a little more than that...

- Add `snapraid_install` / `snapraid_runner` variables
- Rename `snapraid-runner` variables to be specifically about the runner
- Allow specifying multiple custom content files
- Prefix `data_disks` and `parity_disks` so it's obviously about snapraid
- Make healthchecks.io optional
- Allow configuring the healthchecks.io host, allowing for running custom instances
- Add optional cron jobs for `snapraid sync` and `snapraid scrub`

To accomplish this, **there are several breaking changes**, mostly around renaming of variables to separate things just for `snapraid-runner`, and things for everything else. I've shared as much as possible. Sometimes, breaking changes are necessary.

Tested working in https://github.com/RealOrangeOne/infrastructure/commit/09a010f28e72819407def68d1a1ad78e8e47da0f