### PR TITLE
Fix gmail/email typo in variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ snapraid_runner_healthcheck_io_uuid: ""
 snapraid_healthcheck_io_host: https://hc-ping.com
 
 snapraid_runner_email_address: ""
-snapraid_runner_gmail_pass: ""
+snapraid_runner_email_pass: ""
 snapraid_runner_email_address_from: "{{ snapraid_runner_email_address }}"
 snapraid_runner_email_address_to: "{{ snapraid_runner_email_address }}"
 snapraid_runner_email_sendon: "error"

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -30,7 +30,7 @@ port = {{ snapraid_runner_smtp_port }}
 ; set to "true" to activate
 ssl = {{ snapraid_runner_use_ssl }}
 user = {{ snapraid_runner_email_address }}
-password = {{ snapraid_runner_gmail_pass }}
+password = {{ snapraid_runner_email_pass }}
 
 [scrub]
 ; set to true to run scrub after sync


### PR DESCRIPTION
This has bugged me for a bit but finally getting around to submitting the fix.  Noticed that 1 variable is "gmail" while all the others are "email".