### PR TITLE
Don't pipe data into curl for healthchecks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary '@-' {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
+snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -3,7 +3,7 @@
 - name: Schedule snapraid sync
   cron:
     name: snapraid sync
-    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
+    job: snapraid sync {% if snapraid_sync_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_sync_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_sync_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_sync_schedule.minute | default ('0')}}"
@@ -13,7 +13,7 @@
 - name: Schedule snapraid scrub
   cron:
     name: snapraid scrub
-    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}| curl -fsS -m 10 --retry 5 -o /dev/null --data-binary "@-" {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
+    job: snapraid scrub --plan {{ snapraid_scrub_percent }} --older-than {{ snapraid_scrub_age }} {% if snapraid_scrub_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_scrub_healthcheck_io_uuid }}{% endif %}
     user: root
     weekday: "{{ snapraid_scrub_schedule.weekday | default ('*') }}"
     minute: "{{ snapraid_scrub_schedule.minute | default ('0')}}"


### PR DESCRIPTION
This doesn't actually work for healthchecks. Healthchecks just gets the start of the request and assumes everything is working. If the process dies later, healthchecks just sees that as receiving no more data, so assumes everything is fine, when it's not.

This way we lose the logs from healthchecks, but gain it actually working. It can be got back with a wrapper, but that's more than 1 line.