### PR TITLE
Make role usable on RedHat based distros

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ snapraid_runner_email_sendon: "error"
 snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465
 snapraid_runner_use_ssl: true
+snapraid_runner_use_tls: false
 
 snapraid_content_files:
   - /var/snapraid.content

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,8 @@ snapraid_runner: true
 
 snapraid_build_repos: https://github.com/IronicBadger/docker-snapraid.git
 
-snapraid_package_name: snapraid
+snapraid_package_name: "{{ snapraid_apt_package_name }}"
+snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,9 @@
 snapraid_install: true
 snapraid_runner: true
 
-snapraid_apt_package_name: snapraid
+snapraid_build_repos: https://github.com/IronicBadger/docker-snapraid.git
+
+snapraid_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: check whether snapraid is installed
-  shell: "dpkg-query -W '{{ snapraid_apt_package_name }}'"
+  shell: "dpkg-query -W '{{ snapraid_package_name }}'"
   ignore_errors: True
   register: is_installed
   changed_when: "is_installed.rc != 0"
@@ -12,7 +12,7 @@
 
 - name: build snapraid | clone git repo
   git:
-    repo: https://github.com/IronicBadger/docker-snapraid.git
+    repo: "{{ snapraid_build_repos }}"
     dest: /tmp/snapraid
     force: yes
   when: install_snapraid

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,0 +1,37 @@
+---
+
+- name: check packages
+  package_facts:
+    manager: auto
+- name: install snapraid?
+  ansible.builtin.set_fact:
+    install_snapraid: "{{ snapraid_force_install == true or snapraid_package_name not in ansible_facts.packages }}"
+
+- name: build snapraid | clone git repo
+  git:
+    repo: "{{ snapraid_build_repos }}"
+    dest: /tmp/snapraid
+    force: yes
+  when: install_snapraid
+
+- name: build snapraid | make build script executable
+  file:
+    path: /tmp/snapraid/build.sh
+    mode: 0775
+  when: install_snapraid
+
+- name: build snapraid | get info about latest snapraid release
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/amadvance/snapraid/releases/latest
+    return_content: yes
+  register: snapraid_latest
+
+- name: build snapraid | build .rpm package
+  shell: "cd /tmp/snapraid && ./build.sh {{ snapraid_latest.json.tag_name | regex_search('\\d+\\.\\d+') }} rpm"
+  when: install_snapraid
+
+- name: build snapraid | install built .rpm
+  ansible.builtin.dnf:
+    name: /tmp/snapraid/build/snapraid-from-source.rpm
+    state: present
+  when: install_snapraid

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -34,4 +34,5 @@
   ansible.builtin.dnf:
     name: /tmp/snapraid/build/snapraid-from-source.rpm
     state: present
+    disable_gpg_check: true
   when: install_snapraid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: install snapraid
-  include_tasks: install-debian.yml
-  when: ansible_os_family == 'Debian' and snapraid_install
+  include_tasks: "install-{{ ansible_os_family | lower }}.yml"
+  when: snapraid_install
 
 - name: configure snapraid
   include_tasks: configure.yml

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -29,6 +29,7 @@ host = {{ snapraid_runner_smtp_host }}
 port = {{ snapraid_runner_smtp_port }}
 ; set to "true" to activate
 ssl = {{ snapraid_runner_use_ssl }}
+tls = {{ snapraid_runner_use_tls }}
 user = {{ snapraid_runner_email_address }}
 password = {{ snapraid_runner_email_pass }}
 


### PR DESCRIPTION
These changes were made to be able to install and configure snapraid on a Fedora system, but it should also work on other distro using dnf and .rpm packages.

When run under a RedHat based system, the role will make use of the changes proposed by [my previous pull request](https://github.com/ironicbadger/docker-snapraid/pull/25) on [docker-snapraid](https://github.com/ironicbadger/docker-snapraid) to build the package and install it using dnf. Since that PR was not merged yet, I added a new parameter that allows the user to change the repository used to build the package. This way, I could point it to https://github.com/snyssen/docker-snapraid.git where I have the updated code allowing the .rpm builds.

I also took this opportunity to add a missing `tls` flag  for the SMTP config of snapraid-runner