### PR TITLE
Add autosave config option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,9 @@ snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 
-snapraid_autosave_enabled: false
-snapraid_autosave_size_gb: 1024
+snapraid_autosave:
+  enabled: false
+  size_gigabytes: 1024
 
 snapraid_runner_healthcheck_io_uuid: ""
 snapraid_healthcheck_io_host: https://hc-ping.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false
 
+snapraid_autosave_enabled: false
+snapraid_autosave_size_gb: 1024
+
 snapraid_runner_healthcheck_io_uuid: ""
 snapraid_healthcheck_io_host: https://hc-ping.com
 

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -36,6 +36,6 @@ data d{{ loop.index }} {{ disk.path }}{{ disk.data_path | default('') }}
 exclude {{ item }}
 {% endfor %}
 
-{% if snapraid_autosave_enabled %}
-autosave {{ snapraid_autosave_size_gb }}
+{% if snapraid_autosave.enabled %}
+autosave {{ snapraid_autosave.size_gigabytes }}
 {% endif %}

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -37,5 +37,6 @@ exclude {{ item }}
 {% endfor %}
 
 {% if snapraid_autosave.enabled %}
+# Autosaves the state while syncing and scrubbing after the specified amount of GB processed.
 autosave {{ snapraid_autosave.size_gigabytes }}
 {% endif %}

--- a/templates/snapraid.conf.j2
+++ b/templates/snapraid.conf.j2
@@ -35,3 +35,7 @@ data d{{ loop.index }} {{ disk.path }}{{ disk.data_path | default('') }}
 {% for item in snapraid_config_excludes %}
 exclude {{ item }}
 {% endfor %}
+
+{% if snapraid_autosave_enabled %}
+autosave {{ snapraid_autosave_size_gb }}
+{% endif %}


### PR DESCRIPTION
Allows Ansible to add the `autosave` configuration option to `/etc/snapraid.conf`.

For context, this option autosaves the state when scrubbing and syncing once it's processed the amount of GB specified. This is particularly useful when doing long syncs protecting against sudden crashes, power loss, etc: https://www.snapraid.it/manual#7.10

Currently, the feature is off by default as marked by `snapraid_autosave.enabled`.