### PR TITLE
Healthcheck.io job execution time

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 snapraid_install: true
 snapraid_runner: true
+snapraid_runner_repo: "https://github.com/Chronial/snapraid-runner.git"
 
 snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
@@ -20,6 +21,11 @@ snapraid_runner_email_subject: "[SnapRAID] Status Report:"
 snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465
 snapraid_runner_use_ssl: true
+
+snapraid_runner_pushover_token: ""
+snapraid_runner_pushover_user: ""
+snapraid_runner_pushover_sendon: "error,success"
+snapraid_runner_pushover_maxsize: 1024
 
 snapraid_content_files:
   - /var/snapraid.content

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
+snapraid_runner_command: "{% if snapraid_runner_healthcheck_io_uuid %}curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }}/start > /dev/null{% endif %} && python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ snapraid_config_path: /etc/snapraid.conf
 snapraid_runner_path: /opt/snapraid-runner/snapraid-runner
 snapraid_runner_conf: "{{ snapraid_runner_path }}.conf"
 snapraid_runner_bin: "{{ snapraid_runner_path }}.py"
-snapraid_runner_command: "{% if snapraid_runner_healthcheck_io_uuid %}curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }}/start > /dev/null{% endif %} && python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
+snapraid_runner_command: "{% if snapraid_runner_healthcheck_io_uuid %}curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }}/start > /dev/null &&{% endif %} python3 {{ snapraid_runner_bin }} -c {{ snapraid_runner_conf }} {% if snapraid_runner_healthcheck_io_uuid %}&& curl -fsS -m 10 --retry 5 -o /dev/null {{ snapraid_healthcheck_io_host }}/{{ snapraid_runner_healthcheck_io_uuid }} > /dev/null{% endif %}"
 snapraid_runner_scrub: true
 snapraid_scrub_percent: 22
 snapraid_scrub_age: 8

--- a/tasks/snapraid-runner.yml
+++ b/tasks/snapraid-runner.yml
@@ -2,7 +2,7 @@
 
 - name: clone snapraid-runner
   git:
-    repo: https://github.com/Chronial/snapraid-runner.git
+    repo: {{ snapraid_runner_repo }}
     dest: /opt/snapraid-runner
 
 - name: install snapraid-runner configuration file

--- a/tasks/snapraid-runner.yml
+++ b/tasks/snapraid-runner.yml
@@ -2,7 +2,7 @@
 
 - name: clone snapraid-runner
   git:
-    repo: {{ snapraid_runner_repo }}
+    repo: "{{ snapraid_runner_repo }}"
     dest: /opt/snapraid-runner
 
 - name: install snapraid-runner configuration file

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -37,3 +37,9 @@ password = {{ snapraid_runner_email_pass }}
 enabled = {{ snapraid_runner_scrub }}
 percentage = {{ snapraid_scrub_percent }}
 older-than = {{ snapraid_scrub_age }}
+
+[pushover]
+sendon = {{ snapraid_runner_pushover_sendon }}
+token = {{ snapraid_runner_pushover_token }}
+user = {{ snapraid_runner_pushover_user }}
+maxsize = {{ snapraid_runner_pushover_maxsize }}


### PR DESCRIPTION
This PR modifies the `snapraid_runner_command` to first send a ping to the `/start` endpoint of the healthcheck before continuing forward with the already existing invocation of the runner and then the final healthcheck ping.

This modification allows healthcheck.io to calculate the job execution time without any additional changes that may break existing use of the role.