### PR TITLE
Add template value for email subject

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ snapraid_runner_email_pass: ""
 snapraid_runner_email_address_from: "{{ snapraid_runner_email_address }}"
 snapraid_runner_email_address_to: "{{ snapraid_runner_email_address }}"
 snapraid_runner_email_sendon: "error"
+snapraid_runner_email_subject: "[SnapRAID] Status Report:"
 
 snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -19,7 +19,7 @@ maxsize = 5000
 sendon = {{ snapraid_runner_email_sendon }}
 ; set to false to get full program output via email
 short = true
-subject = [SnapRAID] Status Report:
+subject = {{ snapraid_runner_email_subject }}
 from = {{ snapraid_runner_email_address_from }}
 to = {{ snapraid_runner_email_address_to }}
 


### PR DESCRIPTION
Started running two instances of Snapraid on different devices, wanted to be able to tell by email subject which one is having issues.